### PR TITLE
feat(print): add ⌘P printing across renderers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ linux/target/
 
 # Local agent session state
 .claude/
+.dispatcher-state.json

--- a/Sources/AnyViewApp/App.swift
+++ b/Sources/AnyViewApp/App.swift
@@ -39,6 +39,8 @@ struct AnyViewApp {
         fileMenuItem.submenu = fileMenu
         fileMenu.addItem(withTitle: "Open…", action: #selector(AppDelegate.openDocument(_:)), keyEquivalent: "o")
         fileMenu.addItem(withTitle: "Close", action: #selector(NSWindow.performClose(_:)), keyEquivalent: "w")
+        fileMenu.addItem(.separator())
+        fileMenu.addItem(withTitle: "Print…", action: #selector(AppDelegate.printDocument(_:)), keyEquivalent: "p")
 
         // Edit menu — routes ⌘C/⌘A/⌘X/⌘V to first responder (WKWebView)
         let editMenuItem = NSMenuItem()

--- a/Sources/AnyViewApp/AppDelegate.swift
+++ b/Sources/AnyViewApp/AppDelegate.swift
@@ -78,6 +78,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     @objc func findNext(_ sender: Any?) { activeController()?.findNext(sender) }
     @objc func findPrevious(_ sender: Any?) { activeController()?.findPrevious(sender) }
 
+    // MARK: - Print
+
+    @objc func printDocument(_ sender: Any?) { activeController()?.printDocument(sender) }
+
     private func activeController() -> ViewerWindowController? {
         guard let key = NSApp.keyWindow else { return nil }
         return windows.first { $0.window === key }
@@ -100,6 +104,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
            menuItem.action == #selector(findNext(_:)) ||
            menuItem.action == #selector(findPrevious(_:)) {
             return activeController()?.supportsFind == true
+        }
+        if menuItem.action == #selector(printDocument(_:)) {
+            return activeController()?.canPrint == true
         }
         return true
     }

--- a/Sources/AnyViewApp/ImageRenderer.swift
+++ b/Sources/AnyViewApp/ImageRenderer.swift
@@ -1,7 +1,7 @@
 import Cocoa
 
 /// Renders image files using macOS native NSImageView.
-class ImageRenderer: ViewerRenderer {
+class ImageRenderer: ViewerRenderer, SupportsPrint {
     static let supportedExtensions: Set<String> = [
         "png", "jpg", "jpeg", "gif", "webp", "tiff", "tif", "bmp", "ico", "heic", "heif", "svg",
     ]
@@ -53,5 +53,16 @@ class ImageRenderer: ViewerRenderer {
         let size = image.size
         let scaled = NSSize(width: size.width * level, height: size.height * level)
         imageView.frame = NSRect(origin: .zero, size: scaled)
+    }
+
+    var canPrint: Bool { imageView.image != nil }
+
+    func runPrint(attachedTo window: NSWindow?) {
+        guard let image = imageView.image else { return }
+        let printView = ImagePrintView(image: image)
+        let op = NSPrintOperation(view: printView,
+                                  printInfo: PrintHelpers.makePrintInfo(scaleToFit: true))
+        op.jobTitle = "Image"
+        PrintHelpers.run(op, attachedTo: window)
     }
 }

--- a/Sources/AnyViewApp/PDFRenderer.swift
+++ b/Sources/AnyViewApp/PDFRenderer.swift
@@ -2,7 +2,7 @@ import Cocoa
 import PDFKit
 
 /// Renders PDF files using macOS native PDFView.
-class PDFRenderer: ViewerRenderer, SupportsFind {
+class PDFRenderer: ViewerRenderer, SupportsFind, SupportsPrint {
     static let supportedExtensions: Set<String> = ["pdf"]
 
     private let pdfView: PDFView
@@ -36,6 +36,15 @@ class PDFRenderer: ViewerRenderer, SupportsFind {
 
     func setZoom(_ level: CGFloat) {
         pdfView.scaleFactor = level
+    }
+
+    var canPrint: Bool { pdfView.document != nil }
+
+    func runPrint(attachedTo window: NSWindow?) {
+        guard let doc = pdfView.document else { return }
+        PrintHelpers.printPDFDocument(doc,
+                                      jobTitle: PrintHelpers.jobTitle(for: doc.documentURL?.path),
+                                      attachedTo: window)
     }
 
     func performFind(query: String, forward: Bool, completion: @escaping (Bool) -> Void) {

--- a/Sources/AnyViewApp/PrintViews.swift
+++ b/Sources/AnyViewApp/PrintViews.swift
@@ -1,0 +1,135 @@
+import Cocoa
+import PDFKit
+
+/// NSView that paginates a PDFDocument for `NSPrintOperation(view:printInfo:)`.
+/// `rectForPage` returns each page's natural size at origin (0,0); `draw(_:)` consults
+/// `NSPrintOperation.current.currentPage` to pick which page to render. The print system
+/// drives the per-page clip + translate, so per-page positions in our own coord system
+/// don't need to be unique.
+final class PDFPrintView: NSView {
+    private let document: PDFDocument
+    private var pageSizes: [CGSize] = []
+
+    init(document: PDFDocument) {
+        self.document = document
+        super.init(frame: .zero)
+        var maxWidth: CGFloat = 0
+        var maxHeight: CGFloat = 0
+        for i in 0..<document.pageCount {
+            guard let page = document.page(at: i) else {
+                pageSizes.append(.zero); continue
+            }
+            let bounds = page.bounds(for: .mediaBox)
+            let rotation = page.rotation
+            let size: CGSize = (rotation == 90 || rotation == 270)
+                ? CGSize(width: bounds.height, height: bounds.width)
+                : bounds.size
+            pageSizes.append(size)
+            maxWidth = max(maxWidth, size.width)
+            maxHeight = max(maxHeight, size.height)
+        }
+        frame = NSRect(x: 0, y: 0,
+                       width: maxWidth > 0 ? maxWidth : 612,
+                       height: maxHeight > 0 ? maxHeight : 792)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override var isFlipped: Bool { false }
+
+    override func knowsPageRange(_ range: NSRangePointer) -> Bool {
+        range.pointee = NSRange(location: 1, length: document.pageCount)
+        return true
+    }
+
+    override func rectForPage(_ page: Int) -> NSRect {
+        let idx = page - 1
+        guard idx >= 0, idx < pageSizes.count else { return .zero }
+        return NSRect(origin: .zero, size: pageSizes[idx])
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let context = NSGraphicsContext.current?.cgContext,
+              let op = NSPrintOperation.current else { return }
+        let idx = op.currentPage - 1
+        guard idx >= 0, idx < pageSizes.count,
+              let page = document.page(at: idx) else { return }
+        context.saveGState()
+        // PDFPage.transform(for:) bakes in rotation + cropping so the page draws into
+        // a (0,0)-origin rect of the size pageSizes[idx].
+        context.concatenate(page.transform(for: .mediaBox))
+        page.draw(with: .mediaBox, to: context)
+        context.restoreGState()
+    }
+}
+
+/// NSView that prints a single NSImage as a single page, fit to the printable area.
+final class ImagePrintView: NSView {
+    private let image: NSImage
+
+    init(image: NSImage) {
+        self.image = image
+        let size = image.size == .zero ? CGSize(width: 612, height: 792) : image.size
+        super.init(frame: NSRect(origin: .zero, size: size))
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override var isFlipped: Bool { false }
+
+    override func knowsPageRange(_ range: NSRangePointer) -> Bool {
+        range.pointee = NSRange(location: 1, length: 1)
+        return true
+    }
+
+    override func rectForPage(_ page: Int) -> NSRect { bounds }
+
+    override func draw(_ dirtyRect: NSRect) {
+        image.draw(in: bounds,
+                   from: .zero,
+                   operation: .sourceOver,
+                   fraction: 1.0,
+                   respectFlipped: true,
+                   hints: nil)
+    }
+}
+
+enum PrintHelpers {
+    /// `scaleToFit`: shrink the entire view onto a single sheet (use for `ImagePrintView`).
+    /// Otherwise: `.automatic` so the print system honors `knowsPageRange`/`rectForPage`.
+    static func makePrintInfo(scaleToFit: Bool = false) -> NSPrintInfo {
+        let info = NSPrintInfo.shared.copy() as! NSPrintInfo
+        if scaleToFit {
+            info.horizontalPagination = .fit
+            info.verticalPagination = .fit
+            info.isHorizontallyCentered = true
+            info.isVerticallyCentered = true
+        } else {
+            info.horizontalPagination = .automatic
+            info.verticalPagination = .automatic
+        }
+        return info
+    }
+
+    static func run(_ op: NSPrintOperation, attachedTo window: NSWindow?) {
+        if let win = window {
+            op.runModal(for: win, delegate: nil, didRun: nil, contextInfo: nil)
+        } else {
+            op.run()
+        }
+    }
+
+    static func printPDFDocument(_ document: PDFDocument,
+                                 jobTitle: String,
+                                 attachedTo window: NSWindow?) {
+        let view = PDFPrintView(document: document)
+        let op = NSPrintOperation(view: view, printInfo: makePrintInfo())
+        op.jobTitle = jobTitle
+        run(op, attachedTo: window)
+    }
+
+    static func jobTitle(for filePath: String?) -> String {
+        guard let filePath else { return "Document" }
+        return URL(fileURLWithPath: filePath).lastPathComponent
+    }
+}

--- a/Sources/AnyViewApp/QuickLookRenderer.swift
+++ b/Sources/AnyViewApp/QuickLookRenderer.swift
@@ -5,7 +5,7 @@ import Quartz
 /// Renders files using macOS native Quick Look preview.
 /// Handles pptx, xlsx, keynote, numbers, and other Quick Look-supported formats.
 /// For pptx/ppt, also supports a fidelity (LibreOffice → PDF) toggle.
-class QuickLookRenderer: ViewerRenderer, SupportsFidelity {
+class QuickLookRenderer: ViewerRenderer, SupportsFidelity, SupportsPrint {
     static let supportedExtensions: Set<String> = [
         // Office / iWork (xlsx/xls now in WebRenderer via SheetJS)
         "pptx", "ppt",
@@ -188,6 +188,20 @@ class QuickLookRenderer: ViewerRenderer, SupportsFidelity {
         pdfView.scaleFactor = zoomLevel
         previewView.isHidden = true
         pdfView.isHidden = false
+    }
+
+    // MARK: - SupportsPrint
+
+    /// Only printable when fidelity (LibreOffice → PDF) mode is active. QLPreviewView
+    /// doesn't paginate, so we don't try to print the QL preview directly — users
+    /// should toggle fidelity for a real multi-page printout.
+    var canPrint: Bool { fidelityShowingPdf && pdfView.document != nil }
+
+    func runPrint(attachedTo window: NSWindow?) {
+        guard fidelityShowingPdf, let doc = pdfView.document else { return }
+        PrintHelpers.printPDFDocument(doc,
+                                      jobTitle: PrintHelpers.jobTitle(for: currentFilePath),
+                                      attachedTo: window)
     }
 
     private func showOverlay(_ message: String) {

--- a/Sources/AnyViewApp/ViewerRenderer.swift
+++ b/Sources/AnyViewApp/ViewerRenderer.swift
@@ -21,6 +21,15 @@ protocol SupportsFind: AnyObject {
     func performFind(query: String, forward: Bool, completion: @escaping (Bool) -> Void)
 }
 
+/// Renderers that can show the system print panel for the currently displayed content.
+protocol SupportsPrint: AnyObject {
+    /// Whether the renderer currently has something printable. May vary with mode (e.g. fidelity).
+    var canPrint: Bool { get }
+
+    /// Show the print panel. Attaches as a sheet to `window` when possible.
+    func runPrint(attachedTo window: NSWindow?)
+}
+
 /// Errors surfaced by fidelity (LibreOffice → PDF) conversion.
 enum FidelityError: LocalizedError {
     case sofficeNotFound

--- a/Sources/AnyViewApp/ViewerWindowController.swift
+++ b/Sources/AnyViewApp/ViewerWindowController.swift
@@ -381,6 +381,13 @@ class ViewerWindowController: NSObject, NSWindowDelegate, NSToolbarDelegate {
 
     var supportsFind: Bool { renderer is SupportsFind }
 
+    var canPrint: Bool { (renderer as? SupportsPrint)?.canPrint == true }
+
+    @objc func printDocument(_ sender: Any?) {
+        guard let printer = renderer as? SupportsPrint, printer.canPrint else { return }
+        printer.runPrint(attachedTo: window)
+    }
+
     private func showFindBar() {
         guard let container = rendererContainer, let parent = container.superview else { return }
 

--- a/Sources/AnyViewApp/WebRenderer.swift
+++ b/Sources/AnyViewApp/WebRenderer.swift
@@ -17,7 +17,7 @@ private class AnyViewWebView: WKWebView {
 
 /// Renders documents using WKWebView.
 /// Handles docx, docmod, doct, html, markdown, and code files.
-class WebRenderer: NSObject, ViewerRenderer, SupportsFind, SupportsFidelity, WKNavigationDelegate {
+class WebRenderer: NSObject, ViewerRenderer, SupportsFind, SupportsFidelity, SupportsPrint, WKNavigationDelegate {
     static let docExtensions: Set<String> = ["docmod", "doct", "docx"]
     static let xlsxExtensions: Set<String> = ["xlsx", "xls"]
     static let htmlExtensions: Set<String> = ["html", "htm"]
@@ -539,6 +539,27 @@ class WebRenderer: NSObject, ViewerRenderer, SupportsFind, SupportsFidelity, WKN
         }
         NSWorkspace.shared.open(url)
         decisionHandler(.cancel)
+    }
+
+    // MARK: - Print
+
+    var canPrint: Bool {
+        if texShowingPdf || fidelityShowingPdf {
+            return pdfView.document != nil
+        }
+        return currentFilePath != nil
+    }
+
+    func runPrint(attachedTo window: NSWindow?) {
+        if (texShowingPdf || fidelityShowingPdf), let doc = pdfView.document {
+            PrintHelpers.printPDFDocument(doc,
+                                          jobTitle: PrintHelpers.jobTitle(for: currentFilePath),
+                                          attachedTo: window)
+            return
+        }
+        let op = webView.printOperation(with: PrintHelpers.makePrintInfo())
+        op.jobTitle = PrintHelpers.jobTitle(for: currentFilePath)
+        PrintHelpers.run(op, attachedTo: window)
     }
 
     // MARK: - Cleanup


### PR DESCRIPTION
## What

Adds a File ▸ Print… menu item (⌘P) that prints the currently displayed document, routed to the active renderer.

A new `SupportsPrint` protocol gates the feature; `AppDelegate` validates the menu item (greyed out when nothing is printable) and forwards to `ViewerWindowController` → the renderer.

## Per-renderer behavior

- **Image** — single page, scaled to fit the sheet (`ImagePrintView`)
- **PDF** — paginated via `PDFPrintView`, honoring each page's size + rotation
- **QuickLook** — only printable in fidelity (LibreOffice→PDF) mode, since `QLPreviewView` doesn't paginate
- **Web** — native `WKWebView` print op for HTML/docx; PDF path when showing a TeX/fidelity PDF

`PrintViews.swift` holds the paginating `NSView`s and `PrintHelpers`.

## Housekeeping

- Gitignore the local `.dispatcher-state.json` agent state file

## Verification

- `swift build` clean
- `swift test` — 31 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)