### PR TITLE
fix(md): reflow soft-wrapped paragraph lines into a single <p>

### DIFF
--- a/Sources/AnyViewApp/Resources/markdown.js
+++ b/Sources/AnyViewApp/Resources/markdown.js
@@ -45,6 +45,21 @@ function md(s) {
     s = s.replace(/^[\-\*]\s+(.*)$/gm, '<li>$1</li>');
     s = s.replace(/((?:<li>.*<\/li>\n?)+)/g, '<ul>$1</ul>');
     s = s.replace(/^\d+\.\s+(.*)$/gm, '<li>$1</li>');
+    // CommonMark paragraph rule: a single newline within a paragraph is a space,
+    // not a line break. Join consecutive plain-text lines before <p>-wrapping.
+    s = s.split(/\n\n+/).map(function(block) {
+        var lines = block.split('\n');
+        var out = [];
+        for (var i = 0; i < lines.length; i++) {
+            var line = lines[i];
+            if (out.length && line && !line.startsWith('<') && !out[out.length - 1].startsWith('<')) {
+                out[out.length - 1] += ' ' + line;
+            } else {
+                out.push(line);
+            }
+        }
+        return out.join('\n');
+    }).join('\n\n');
     s = s.replace(/^(?!<[hupoltbd]|<li|<bl|<hr|<im|<a )(.+)$/gm, '<p>$1</p>');
     s = s.replace(/<\/blockquote>\n<blockquote>/g, '<br>');
     s = s.replace(/<div data-mermaid-placeholder="(\d+)"><\/div>/g, function(_, idx) {

--- a/Tests/WebRendererMdTests/md.test.js
+++ b/Tests/WebRendererMdTests/md.test.js
@@ -82,6 +82,37 @@ test('test_code_block_content_has_no_injected_tags', function() {
     );
 });
 
+test('test_soft_wrapped_paragraph_lines_join_as_space', function() {
+    // CommonMark: a single newline inside a paragraph is a space, not a <br>.
+    // Multi-line paragraphs from source files wrapped at ~80 chars must reflow.
+    const input = 'First line of paragraph\nsecond line of paragraph\nthird line.\n\nNew paragraph.';
+    const out = md(input);
+    assert.ok(
+        out.indexOf('<p>First line of paragraph second line of paragraph third line.</p>') !== -1,
+        'soft-wrapped lines must join into one <p>: ' + out
+    );
+    assert.ok(
+        out.indexOf('<p>New paragraph.</p>') !== -1,
+        'blank-line-separated paragraph must remain separate: ' + out
+    );
+    assert.ok(
+        out.indexOf('<p>second line') === -1,
+        'second line must not become its own <p>: ' + out
+    );
+});
+
+test('test_soft_wrap_does_not_merge_across_block_elements', function() {
+    // A plain-text line must not be joined with an adjacent heading or list.
+    const input = '# Heading\n\nParagraph line one\nparagraph line two.\n\n- item';
+    const out = md(input);
+    assert.ok(out.indexOf('<h1>Heading</h1>') !== -1, 'heading must survive: ' + out);
+    assert.ok(
+        out.indexOf('<p>Paragraph line one paragraph line two.</p>') !== -1,
+        'paragraph lines must join: ' + out
+    );
+    assert.ok(/<li>item<\/li>/.test(out), 'list item must survive: ' + out);
+});
+
 test('test_mixed_document_keeps_h1_ul_table_p', function() {
     // A document mixing a heading, an unordered list, a table and a plain
     // paragraph must still render each element to its own block: the


### PR DESCRIPTION
## Summary

- CommonMark rule: a single newline inside a paragraph is a space, not a line break
- Previously each source line became its own `<p>`, causing early wrapping with a wide blank margin on the right
- Fix: join consecutive plain-text lines within a block (separated by blank lines) before `<p>`-wrapping; HTML block elements (headings, list items, etc.) are left untouched

## Test plan

- [x] 2 new unit tests in `md.test.js` covering soft-wrap joining and no merging across block elements
- [x] All 6 tests pass (`node Tests/WebRendererMdTests/md.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)