### PR TITLE
fix(md): join paragraph lines that start with inline HTML tags

### DIFF
--- a/Sources/AnyViewApp/Resources/markdown.js
+++ b/Sources/AnyViewApp/Resources/markdown.js
@@ -47,12 +47,17 @@ function md(s) {
     s = s.replace(/^\d+\.\s+(.*)$/gm, '<li>$1</li>');
     // CommonMark paragraph rule: a single newline within a paragraph is a space,
     // not a line break. Join consecutive plain-text lines before <p>-wrapping.
+    // Only block-level tags (headings, ul/li, table, hr, div, pre) act as
+    // paragraph boundaries; inline tags (<a>, <code>, <b>, <i>, <img>) do not.
+    function isBlockTag(line) {
+        return /^<(?:h[1-6]|ul|li|table|thead|tbody|tr|th|td|blockquote|hr|div|pre)\b/i.test(line);
+    }
     s = s.split(/\n\n+/).map(function(block) {
         var lines = block.split('\n');
         var out = [];
         for (var i = 0; i < lines.length; i++) {
             var line = lines[i];
-            if (out.length && line && !line.startsWith('<') && !out[out.length - 1].startsWith('<')) {
+            if (out.length && line && !isBlockTag(line) && !isBlockTag(out[out.length - 1])) {
                 out[out.length - 1] += ' ' + line;
             } else {
                 out.push(line);

--- a/Tests/WebRendererMdTests/md.test.js
+++ b/Tests/WebRendererMdTests/md.test.js
@@ -101,6 +101,27 @@ test('test_soft_wrapped_paragraph_lines_join_as_space', function() {
     );
 });
 
+test('test_soft_wrap_joins_line_starting_with_inline_tag', function() {
+    // A paragraph line that starts with an inline element (<a>, <code>) after
+    // inline processing must still be joined with the preceding line.
+    // Regression: the original fix treated any "<"-starting line as a block boundary.
+    const input = 'Visit [example](http://example.com) and serves as\nthe barrier.';
+    const out = md(input);
+    assert.ok(
+        !/<p>the barrier\.?<\/p>/.test(out),
+        'line starting with plain text after a link line must join: ' + out
+    );
+    // paragraph starting mid-line with a link followed by continuation
+    const input2 = 'Prefix text\n[link](http://x.com) continuation text';
+    const out2 = md(input2);
+    assert.ok(
+        out2.indexOf('Prefix text') !== -1 && out2.indexOf('continuation text') !== -1,
+        'link-starting continuation line must join: ' + out2
+    );
+    const count2 = (out2.match(/<p>/g) || []).length;
+    assert.strictEqual(count2, 1, 'must produce exactly one <p>: ' + out2);
+});
+
 test('test_soft_wrap_does_not_merge_across_block_elements', function() {
     // A plain-text line must not be joined with an adjacent heading or list.
     const input = '# Heading\n\nParagraph line one\nparagraph line two.\n\n- item';


### PR DESCRIPTION
## Summary

- The previous soft-wrap fix treated any `<`-starting line as a block boundary, so lines beginning with `<a>` (links) or `<code>` (inline code) were skipped — leaving visible line breaks in paragraphs like the intro of `v0.3-test-contract.md`
- Fix: check specifically for block-level tags (`h1-h6`, `ul`, `li`, `table`, `thead`, `tbody`, `tr`, `th`, `td`, `blockquote`, `hr`, `div`, `pre`); inline tags are treated as plain text and joined normally

## Test plan

- [x] New test `test_soft_wrap_joins_line_starting_with_inline_tag` covers the regression
- [x] All 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)